### PR TITLE
[RFC] Get values from per-cpu maps

### DIFF
--- a/lib/map/map.ts
+++ b/lib/map/map.ts
@@ -334,7 +334,7 @@ export class RawMap implements IMap<Buffer, Buffer> {
         this._kBuf(key)
         const nr_cpus = native.getNumPossibleCPUs()
         checkStatus('libbpf_num_possible_cpus', nr_cpus)
-	// allocate large enough Buffer to store values read from all CPUs
+        // allocate large enough Buffer to store values read from all CPUs
         out = this._getBuf(this.ref.valueSize * nr_cpus, out)
         const status = native.mapLookupElem(this.ref.fd, key, out, flags)
         if (status == -ENOENT)

--- a/lib/map/map.ts
+++ b/lib/map/map.ts
@@ -329,10 +329,12 @@ export class RawMap implements IMap<Buffer, Buffer> {
         return out
     }
 
+    // Get all values from per-cpu maps
     getPerCPU(key: Buffer, flags: number = 0, out?: Buffer): Buffer | undefined {
         this._kBuf(key)
         const nr_cpus = native.getNumPossibleCPUs()
         checkStatus('libbpf_num_possible_cpus', nr_cpus)
+	// allocate large enough Buffer to store values read from all CPUs
         out = this._getBuf(this.ref.valueSize * nr_cpus, out)
         const status = native.mapLookupElem(this.ref.fd, key, out, flags)
         if (status == -ENOENT)

--- a/lib/map/map.ts
+++ b/lib/map/map.ts
@@ -329,6 +329,18 @@ export class RawMap implements IMap<Buffer, Buffer> {
         return out
     }
 
+    getPerCPU(key: Buffer, flags: number = 0, out?: Buffer): Buffer | undefined {
+        this._kBuf(key)
+	const nr_cpus = native.getNumPossibleCPUs()
+	checkStatus('libbpf_num_possible_cpus', nr_cpus)
+        out = this._getBuf(this.ref.valueSize * nr_cpus, out)
+        const status = native.mapLookupElem(this.ref.fd, key, out, flags)
+        if (status == -ENOENT)
+            return undefined
+        checkStatus('bpf_map_lookup_elem_flags', status)
+        return out
+    }
+
     getDelete(key: Buffer, out?: Buffer): Buffer | undefined {
         this._kBuf(key)
         out = this._vOrBuf(out)

--- a/lib/map/map.ts
+++ b/lib/map/map.ts
@@ -331,8 +331,8 @@ export class RawMap implements IMap<Buffer, Buffer> {
 
     getPerCPU(key: Buffer, flags: number = 0, out?: Buffer): Buffer | undefined {
         this._kBuf(key)
-	const nr_cpus = native.getNumPossibleCPUs()
-	checkStatus('libbpf_num_possible_cpus', nr_cpus)
+        const nr_cpus = native.getNumPossibleCPUs()
+        checkStatus('libbpf_num_possible_cpus', nr_cpus)
         out = this._getBuf(this.ref.valueSize * nr_cpus, out)
         const status = native.mapLookupElem(this.ref.fd, key, out, flags)
         if (status == -ENOENT)

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -10,6 +10,7 @@
 #include <sys/utsname.h>
 
 #include <bpf.h>
+#include <libbpf.h>
 #include <errno.h>
 
 #include <napi.h>
@@ -315,6 +316,11 @@ Napi::Value BpfObjGet(const CallbackInfo& info) {
     return ToStatus(env, bpf_obj_get(path.c_str()));
 }
 
+Napi::Value GetNumPossibleCPUs(const CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    return ToStatus(env, libbpf_num_possible_cpus());
+}
+
 #define EXPOSE_FUNCTION(NAME, METHOD) exports.Set(NAME, Napi::Function::New(env, METHOD, NAME))
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
@@ -345,6 +351,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
     EXPOSE_FUNCTION("getMapInfo", GetMapInfo);
     EXPOSE_FUNCTION("mapGetFdById", MapGetFdById);
     EXPOSE_FUNCTION("bpfObjGet", BpfObjGet);
+    EXPOSE_FUNCTION("getNumPossibleCPUs", GetNumPossibleCPUs);
 
     return exports;
 }


### PR DESCRIPTION
Per-cpu maps are special, they store multiple values to a single key; a value for each CPU core. The `bpf_map_lookup_elem()` returns all these values. But when I call a `get()` on a RawMap, it returns a single value only since it allocates a buffer which is as long as the map's value size. To handle per-cpu maps, I propose a new `getPerCPU()` function which returns a buffer containing all values. wdyt?